### PR TITLE
Update cli.py with config file path operand error

### DIFF
--- a/pathopatch/cli.py
+++ b/pathopatch/cli.py
@@ -682,13 +682,17 @@ class PreProcessingParser(ABCParser):
         }
         for k, v in config_repr_str.items():
             config_repr[k] = v
+        # convert the string to Path
+        log_path = Path(self.preprocessing.log_path)
+
+        #using the / to join paths
+        config_file_path = log_path / "config.yaml"
+
         # store in log directory
-        with open(self.preprocessconfig.log_path / "config.yaml", "w") as yaml_file:
+        with open(config_file_path, "w") as yaml_file:
             yaml.dump(config_repr, yaml_file, sort_keys=False)
 
-        self.logger.debug(
-            f"Stored config under: {str(self.preprocessconfig.log_path / 'config.yaml')}"
-        )
+        self.logger.info(f"Stored config under: {config_file_path}")
 
 
 class MacenkoYamlConfig(PreProcessingYamlConfig):


### PR DESCRIPTION
`log_path` issue for the storing of the config file while preprocessing.
```
~$ wsi_extraction --config configs/patch_extraction_tiles-l1-s256.yaml 
Traceback (most recent call last):
  File "/projects/envs/conda/psgudla/envs/cellvit_env/bin/wsi_extraction", line 8, in <module>
    sys.exit(main())
  File "/projects/envs/conda/psgudla/envs/cellvit_env/lib/python3.9/site-packages/pathopatch/wsi_extraction.py", line 31, in main
    configuration_parser.store_config()
  File "/projects/envs/conda/psgudla/envs/cellvit_env/lib/python3.9/site-packages/pathopatch/cli.py", line 686, in store_config
    with open(self.preprocessconfig.log_path / "config.yaml", "w") as yaml_file:
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```
